### PR TITLE
dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         }
     },
     "dependencies": {
+        "@floating-ui/react": "^0.27.4",
         "@radix-ui/react-scroll-area": "^1.2.2",
         "@radix-ui/react-select": "^2.1.4",
         "@uiw/react-textarea-code-editor": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@floating-ui/react':
+        specifier: ^0.27.4
+        version: 0.27.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.2
         version: 1.2.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -564,6 +567,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.4':
+    resolution: {integrity: sha512-05mXdkUiVh8NCEcYKQ2C9SV9IkZ9k/dFtYmaEIN2riLv80UHoXylgBM76cgPJYfLJM3dJz7UE5MOVH0FypMd2Q==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
@@ -4630,6 +4639,9 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tabbable@6.2.0:
+    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
@@ -5576,6 +5588,14 @@ snapshots:
       '@floating-ui/dom': 1.6.13
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+
+  '@floating-ui/react@0.27.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@floating-ui/utils': 0.2.9
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.9': {}
 
@@ -10306,6 +10326,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tabbable@6.2.0: {}
 
   tailwind-merge@2.6.0: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,10 @@
 import { Main } from "@/layout";
-import { AppProvider, PaletteProvider, ToolsProvider } from "@/context";
+import {
+    AppProvider,
+    PaletteProvider,
+    ToolsProvider,
+    NodeOptionsProvider,
+} from "@/context";
 import { BrowserRouter } from "react-router";
 
 function App() {
@@ -8,7 +13,9 @@ function App() {
             <AppProvider>
                 <PaletteProvider>
                     <ToolsProvider>
-                        <Main />
+                        <NodeOptionsProvider>
+                            <Main />
+                        </NodeOptionsProvider>
                     </ToolsProvider>
                 </PaletteProvider>
             </AppProvider>

--- a/src/components/button-group/types.ts
+++ b/src/components/button-group/types.ts
@@ -4,4 +4,7 @@ import { buttonGroupVariants } from "./variants";
 
 export type ButtonGroupContextType = VariantProps<typeof buttonGroupVariants>;
 
-export type ButtonGroupProps = GroupProps & ButtonGroupContextType;
+export type ButtonGroupProps = GroupProps &
+    ButtonGroupContextType & {
+        ref?: React.Ref<HTMLDivElement>;
+    };

--- a/src/components/button-group/variants.ts
+++ b/src/components/button-group/variants.ts
@@ -8,8 +8,6 @@ export const buttonGroupVariants = cva(
         "justify-center",
         "items-center",
         "border",
-        "mt-2",
-        "lg:mt-3",
 
         "transform",
         "duration-300",

--- a/src/components/button/variant.ts
+++ b/src/components/button/variant.ts
@@ -23,7 +23,7 @@ export const buttonVariants = cva(
                     "rounded-sm",
                     "border",
                     "border-gray-800",
-                    "hover:bg-gray-00",
+                    "hover:bg-gray-300",
                 ],
                 trigger: [
                     "flex",
@@ -32,7 +32,7 @@ export const buttonVariants = cva(
                     "p-2",
                     "border",
                     "border-gray-800",
-                    "hover:bg-gray-00",
+                    "hover:bg-gray-300",
                     "z-20",
                     "duration-300",
                 ],

--- a/src/components/links/Links.tsx
+++ b/src/components/links/Links.tsx
@@ -127,12 +127,12 @@ export function Links({ current }: LinksProps) {
         }
     };
 
-    const colorA = getVertex(current)?.color.data;
+    const colorA = getVertex(current)?.color;
 
     return (
         <div className={cn("flex", "flex-col", "w-full", "gap-4")}>
             {getNodeEdges(current)?.map(({ source, target }) => {
-                const colorB = getVertex(target)?.color.data;
+                const colorB = getVertex(target)?.color;
 
                 return (
                     <div
@@ -154,20 +154,14 @@ export function Links({ current }: LinksProps) {
                                 "items-center"
                             )}
                         >
-                            <ColorSwatch
-                                size={"small"}
-                                color={getVertex(source)?.color.data}
-                            />
+                            <ColorSwatch size={"small"} color={colorA?.data} />
                             {isDirEdge(current, target) ? (
                                 <ArrowRight size={16} />
                             ) : (
                                 <ArrowLeftRight size={16} />
                             )}
-                            <ColorSwatch
-                                size={"small"}
-                                color={getVertex(target)?.color.data}
-                            />
-                            {getVertex(target)?.color.title || target}
+                            <ColorSwatch size={"small"} color={colorB?.data} />
+                            {colorB?.title || colorB?.data.toString("hex")}
                         </div>
                         <div
                             className={cn(
@@ -200,13 +194,13 @@ export function Links({ current }: LinksProps) {
                                     <span>aa</span>
                                     {icon(
                                         validator?.isLevelAA(
-                                            colorA!.toString("hex"),
-                                            colorB!.toString("hex"),
+                                            colorA!.data.toString("hex"),
+                                            colorB!.data.toString("hex"),
                                             24
                                         ),
                                         validator?.isLevelAA(
-                                            colorA!.toString("hex"),
-                                            colorB!.toString("hex"),
+                                            colorA!.data.toString("hex"),
+                                            colorB!.data.toString("hex"),
                                             18
                                         )
                                     )}
@@ -223,19 +217,20 @@ export function Links({ current }: LinksProps) {
                                     <span>aaa</span>
                                     {icon(
                                         validator?.isLevelAAA(
-                                            colorA!.toString("hex"),
-                                            colorB!.toString("hex"),
+                                            colorA!.data.toString("hex"),
+                                            colorB!.data.toString("hex"),
                                             24
                                         ),
                                         validator?.isLevelAAA(
-                                            colorA!.toString("hex"),
-                                            colorB!.toString("hex"),
+                                            colorA!.data.toString("hex"),
+                                            colorB!.data.toString("hex"),
                                             18
                                         )
                                     )}
                                 </div>
                             </div>
                             <Button
+                                aria-label="remove link"
                                 variant={"none"}
                                 className={cn(
                                     "invisible",

--- a/src/components/picker/ColorField.tsx
+++ b/src/components/picker/ColorField.tsx
@@ -1,4 +1,5 @@
 import {
+    Color,
     ColorField as Primitive,
     ColorFieldProps as PrimitiveType,
 } from "react-aria-components";
@@ -7,9 +8,11 @@ import { Label, Input, InputProps } from "@/components";
 import { usePickerContext } from "./Context";
 import { cn } from "@/lib";
 
-export type ColorFieldProps = PrimitiveType & {
-    label?: string;
-} & InputProps;
+export type ColorFieldProps = Omit<InputProps, "value"> &
+    PrimitiveType & {
+        label?: string;
+        value?: Color;
+    };
 
 export function ColorField({ label, size, ...props }: ColorFieldProps) {
     const { fieldProps } = usePickerContext();

--- a/src/components/picker/ColorSwatch.tsx
+++ b/src/components/picker/ColorSwatch.tsx
@@ -4,7 +4,7 @@ import {
     ColorSwatchProps,
 } from "react-aria-components";
 
-const colorSwatchVariants = cva(["rounded-full", "border", "border-gray-800"], {
+const colorSwatchVariants = cva(["border", "border-gray-800"], {
     variants: {
         size: {
             small: ["w-4", "h-4"],

--- a/src/components/picker/ColorThumb.tsx
+++ b/src/components/picker/ColorThumb.tsx
@@ -23,6 +23,9 @@ export function ColorThumb({ className, ...props }: ColorThumbProps) {
                 "ring-offset-2",
                 "ring-offset-white",
 
+                "focus-within:ring-2",
+                "focus-within:ring-black",
+
                 String(className)
             )}
             {...thumbProps}

--- a/src/components/picker/Picker.tsx
+++ b/src/components/picker/Picker.tsx
@@ -1,11 +1,6 @@
 import { PickerProps } from "./types";
 import { cn } from "@/lib";
-import {
-    ColorArea,
-    ColorSlider,
-    ColorField,
-    Label,
-} from "@/components";
+import { ColorArea, ColorSlider, ColorField, Label } from "@/components";
 import { usePaletteContext } from "@/context";
 import { PickerProvider } from "./Provider";
 
@@ -19,12 +14,10 @@ export function Picker({ color, title, onChange }: PickerProps) {
             colorSpace={colorSpace}
         >
             <Label title={title} className={cn("w-full")}>
-                <div className={cn("w-full", "flex", "flex-col", "gap-2", "p")}>
-                    <div className={cn("flex", "flex-col", "w-full")}>
-                        <div className={cn("flex", "flex-row", "w-full", "gap-2")}>
-                            <ColorSlider />
-                            <ColorArea />
-                        </div>
+                <div className={cn("w-full", "flex", "flex-col", "gap-2")}>
+                    <div className={cn("flex", "gap-2")}>
+                        <ColorSlider />
+                        <ColorArea />
                     </div>
 
                     <ColorField

--- a/src/components/picker/Provider.tsx
+++ b/src/components/picker/Provider.tsx
@@ -10,7 +10,7 @@ import {
 export function PickerProvider({
     color,
     onChange,
-    children
+    children,
 }: React.PropsWithChildren<PickerContextProps>) {
     const [colorSpace] = useState<ColorSpace>("hsl");
 
@@ -19,30 +19,34 @@ export function PickerProvider({
             xChannel: "saturation",
             yChannel: "lightness",
 
-            colorSpace: colorSpace,
-            value: color.toString("hex"),
+            colorSpace,
+            value: color,
+
             onChange,
         },
         thumbProps: {},
         sliderProps: {
             orientation: "vertical",
             channel: "hue",
-            colorSpace: colorSpace,
-            value: color.toString("hex"),
+
+            colorSpace,
+            value: color,
             onChange,
         },
         fieldProps: {
-            colorSpace: colorSpace,
-            value: color.toString("hex"),
-            onChange: (c: PrimitiveColor | ChangeEvent<HTMLInputElement> | null) => {
+            colorSpace,
+            value: color,
+            onChange: (
+                c: PrimitiveColor | ChangeEvent<HTMLInputElement> | null
+            ) => {
                 if (!c) return;
                 if ("target" in c) {
                     c = parseColor(c.target.value);
                 }
-                onChange?.(c.toFormat(colorSpace));
-            }
+                onChange?.(c);
+            },
         },
-    }
+    };
 
     const value = {
         ...PickerContextDefault,

--- a/src/context/app/Context.ts
+++ b/src/context/app/Context.ts
@@ -8,6 +8,8 @@ export const AppDefaults: AppType = {
         nodes: new Map(),
         edges: new Map(),
     },
+    graphInstance: null,
+    setGraphInstance: () => {},
 
     getVertices: () => [],
     getEdges: () => [],

--- a/src/context/app/Provider.tsx
+++ b/src/context/app/Provider.tsx
@@ -9,7 +9,11 @@ import { Node, Link } from "./";
 import { ForceGraphMethods, ForceGraphProps } from "react-force-graph-2d";
 
 export function AppProvider({ children }: React.PropsWithChildren) {
-    const graphRef = useRef<ForceGraphMethods<Node, Link>>(null);
+    const graphRef = useRef<HTMLElement & ForceGraphMethods<Node, Link>>(null);
+
+    const [graphInstance, setGraphInstance] = useState<
+        (HTMLElement & ForceGraphMethods<Node, Link>) | null
+    >(null);
 
     const { graph, ...graphActions } = useGraph<Node, Link>(
         (() => {
@@ -137,7 +141,9 @@ export function AppProvider({ children }: React.PropsWithChildren) {
         <AppContext
             value={{
                 graphRef,
+                graphInstance,
                 graph,
+                setGraphInstance,
                 updateStorage,
 
                 sidebar,

--- a/src/context/app/types.ts
+++ b/src/context/app/types.ts
@@ -27,13 +27,20 @@ export type Node = NodeType<
 export type Link = LinkType<Node>;
 
 export type AppType = ReturnType<typeof useGraph<Node, Link>> & {
-    graphRef?: React.RefObject<ForceGraphMethods<Node, Link> | null>;
+    graphRef?: React.RefObject<
+        (HTMLElement & ForceGraphMethods<Node, Link>) | null
+    >;
+
+    graphInstance: (HTMLElement & ForceGraphMethods<Node, Link>) | null;
     options: ForceGraphProps<Node, Link>;
     viewport: Viewport;
     sidebar: boolean;
     scale: number;
     setScale: Dispatch<SetStateAction<number>>;
 
+    setGraphInstance: Dispatch<
+        SetStateAction<(HTMLElement & ForceGraphMethods<Node, Link>) | null>
+    >;
     updateStorage: () => void;
     setSidebar: Dispatch<SetStateAction<boolean>>;
 };

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,3 +1,4 @@
 export * from "./app";
 export * from "./palette";
 export * from "./tools";
+export * from "./node-options";

--- a/src/context/node-options/Context.ts
+++ b/src/context/node-options/Context.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+import { NodeOptionsType } from "./types";
+
+export const NodeOptionsDefault: NodeOptionsType = {
+    ref: null,
+    floatingRef: null,
+    floatingStyles: {},
+    selected: undefined,
+    referenceProps: () => ({}),
+    floatingProps: () => ({}),
+    setSelected: () => {},
+    removeNode: () => {},
+    duplicateNode: () => {},
+    setConnection: () => {},
+    resetConnection: () => {},
+};
+
+export const NodeOptionsContext =
+    createContext<NodeOptionsType>(NodeOptionsDefault);
+
+export function useNodeOptionsContext() {
+    return useContext(NodeOptionsContext);
+}

--- a/src/context/node-options/Provider.tsx
+++ b/src/context/node-options/Provider.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, Node, useAppContext } from "../app";
+import { NodeOptionsContext } from "./Context";
+
+import {
+    useClientPoint,
+    useFloating,
+    useInteractions,
+    useMergeRefs,
+} from "@floating-ui/react";
+import { ForceGraphMethods } from "react-force-graph-2d";
+import { NodeOption } from "@/features";
+import { usePaletteContext } from "../palette";
+
+export function NodeOptionsProvider({ children }: React.PropsWithChildren) {
+    // get app context
+    const {
+        graphRef,
+        graphInstance,
+        options,
+        setGraphInstance,
+        getVertex,
+        addDirEdge,
+    } = useAppContext();
+
+    const { onColorRemove, onColorDuplicate } = usePaletteContext();
+
+    // selected node state
+    const [selected, setSel] = useState<Node["id"]>();
+
+    // connection state
+    const [connection, setConn] = useState<Partial<Link>>();
+
+    // get selected node
+    const node = useMemo(() => {
+        if (!selected) return undefined;
+        return getVertex(selected);
+    }, [getVertex, selected]);
+
+    // get node position
+    const { x, y } = useMemo(() => {
+        if (!node || !graphInstance) return { x: 0, y: 0 };
+        return graphInstance.graph2ScreenCoords(node.x!, node.y!);
+    }, [graphInstance, node]);
+
+    // get floating ui
+    const { refs, floatingStyles, context } = useFloating();
+
+    // get client point
+    const clientPoint = useClientPoint(context, {
+        x: x + options.nodeRelSize! * 2,
+        y,
+    });
+
+    /**
+     * Set connection
+     */
+    const setConnection = (id: Node["id"]) => {
+        if (!connection || typeof connection.source === "undefined") {
+            setConn({ source: id });
+        } else {
+            setConn({ ...connection, target: id });
+        }
+    };
+
+    /**
+     * Reset connection
+     */
+    const resetConnection = () => {
+        setConn(undefined);
+    };
+
+    // get reference and floating props
+    const { getReferenceProps, getFloatingProps } = useInteractions([
+        clientPoint,
+    ]);
+
+    /**
+     * Fixed ref
+     */
+    const fixedRef = useCallback(
+        (el: (HTMLElement & ForceGraphMethods<Node, Link>) | null) => {
+            if (!el) return;
+            setGraphInstance(el);
+        },
+        [setGraphInstance]
+    );
+
+    /**
+     * Remove node
+     * @param id | Node["id"]
+     */
+    const removeNode = (id: Node["id"]) => {
+        onColorRemove(id);
+        setSel(undefined);
+    };
+
+    /**
+     * Duplicate node
+     * @param id | Node["id"]
+     */
+    const duplicateNode = (id: Node["id"]) => {
+        onColorDuplicate(id);
+        setSel(undefined);
+    };
+
+    /**
+     * Set selected
+     * @param id | Node["id"] | undefined
+     */
+    const setSelected = useCallback(
+        (id: Node["id"] | undefined) => {
+            if (!id) {
+                setSel(undefined);
+                return;
+            }
+            const node = getVertex(id);
+            if (!node?.expanded) {
+                setSel((prev) => (prev === id ? undefined : id));
+            } else {
+                setSel(undefined);
+            }
+        },
+        [getVertex]
+    );
+
+    // merge refs
+    const ref = useMergeRefs([graphRef, refs.setReference, fixedRef]);
+
+    // add dir edge effect
+    useEffect(() => {
+        if (!connection) return;
+        if (
+            typeof connection.source !== "undefined" &&
+            typeof connection.target !== "undefined"
+        ) {
+            addDirEdge(connection as Link);
+            setConn(undefined);
+            setSelected(undefined);
+        }
+    }, [addDirEdge, setSelected, connection, selected]);
+
+    return (
+        <NodeOptionsContext
+            value={{
+                ref,
+                setSelected,
+                floatingRef: refs.setFloating,
+                floatingProps: getFloatingProps,
+                referenceProps: getReferenceProps,
+
+                removeNode,
+                duplicateNode,
+
+                setConnection,
+                resetConnection,
+
+                connection,
+                node,
+                selected,
+                floatingStyles,
+            }}
+        >
+            {children}
+            <NodeOption />
+        </NodeOptionsContext>
+    );
+}

--- a/src/context/node-options/index.ts
+++ b/src/context/node-options/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./Context";
+export * from "./Provider";

--- a/src/context/node-options/types.ts
+++ b/src/context/node-options/types.ts
@@ -1,0 +1,27 @@
+import { RefCallback } from "react";
+import { ForceGraphMethods } from "react-force-graph-2d";
+import { Link, Node } from "../app";
+
+export type NodeOptionsType = {
+    ref: RefCallback<HTMLElement & ForceGraphMethods<Node, Link>> | null;
+    floatingRef: RefCallback<HTMLElement> | null;
+    floatingStyles: React.CSSProperties;
+    selected: Node["id"] | undefined;
+    node?: Node;
+    connection?: Partial<Link>;
+
+    referenceProps: (
+        userProps?: React.HTMLProps<Element>
+    ) => Record<string, unknown>;
+    floatingProps: (
+        userProps?: React.HTMLProps<HTMLElement>
+    ) => Record<string, unknown>;
+
+    setSelected: (node: Node["id"] | undefined) => void;
+
+    removeNode: (id: Node["id"]) => void;
+    duplicateNode: (id: Node["id"]) => void;
+
+    setConnection: (id: Node["id"]) => void;
+    resetConnection: () => void;
+};

--- a/src/context/palette/Context.ts
+++ b/src/context/palette/Context.ts
@@ -27,6 +27,7 @@ export type PaletteContextCallback = {
     getBackground: () => Color | undefined;
     getBackgroundHex: () => string;
     onColorAdd: () => void;
+    onColorDuplicate: (id: string) => void;
     onColorRemove: (id: string) => void;
     contrastColor: (
         foreground: string,
@@ -49,6 +50,7 @@ export const PaletteCallback: PaletteContextCallback = {
     getBackground: () => undefined,
     getBackgroundHex: () => "#FFF",
     onColorAdd: () => {},
+    onColorDuplicate: () => {},
     onColorRemove: () => {},
     contrastColor: () => "black",
     updateColorName: () => {},

--- a/src/context/palette/Provider.tsx
+++ b/src/context/palette/Provider.tsx
@@ -96,6 +96,33 @@ export function PaletteProvider({
     };
 
     /**
+     * Duplicate a color in the palette
+     * @param id | id of the color
+     *
+     * @posthog color_duplicate event
+     */
+    const onColorDuplicate = (id: string) => {
+        const color = getColor(id);
+        if (!color) return;
+
+        const newId = getRandomId();
+        graphActions.addVertex({
+            id: newId,
+            expanded: true,
+            val: 1.5,
+            color: {
+                ...color,
+                id: newId,
+            },
+        });
+
+        posthog?.capture("color_duplicate", {
+            id,
+            newId,
+        });
+    };
+
+    /**
      * Remove a color from the palette
      * @param id | id of the color
      *
@@ -298,6 +325,7 @@ export function PaletteProvider({
                 getBackgroundHex,
                 contrastColor,
                 onColorAdd,
+                onColorDuplicate,
                 onColorRemove,
                 updateColorName,
                 updateColorData,

--- a/src/context/palette/Provider.tsx
+++ b/src/context/palette/Provider.tsx
@@ -300,11 +300,7 @@ export function PaletteProvider({
      * @posthog link_remove event
      */
     const onLinkRemove = (source: string, target: string) => {
-        if (graphActions.isDirEdge(source, target)) {
-            graphActions.removeDirEdge({ source, target });
-        } else {
-            graphActions.removeEdge({ source, target });
-        }
+        graphActions.removeDirEdge({ source, target });
 
         posthog?.capture("link_remove", {
             source,

--- a/src/features/colors-layers/ColorsLayers.tsx
+++ b/src/features/colors-layers/ColorsLayers.tsx
@@ -25,7 +25,7 @@ export function ColorsLayers() {
         return getVertex(id)?.expanded || false;
     };
 
-    const { onColorAdd, onColorRemove } = usePaletteContext();
+    const { onColorAdd, onColorRemove, onColorDuplicate } = usePaletteContext();
 
     return (
         <ColorsLayersContext
@@ -33,9 +33,11 @@ export function ColorsLayers() {
                 setExpanded,
                 isExpanded,
                 removeItem: onColorRemove,
+                duplicateItem: onColorDuplicate,
             }}
         >
             <Button
+                aria-label="Add color"
                 variant={"square"}
                 className={cn(
                     "flex",

--- a/src/features/colors-layers/Context.tsx
+++ b/src/features/colors-layers/Context.tsx
@@ -5,6 +5,7 @@ export const colorsLayersContextDefault: ColorsLayersContextType = {
     setExpanded: () => {},
     removeItem: () => {},
     isExpanded: () => false,
+    duplicateItem: () => {},
 };
 
 export const ColorsLayersContext = createContext(colorsLayersContextDefault);

--- a/src/features/colors-layers/Layer.tsx
+++ b/src/features/colors-layers/Layer.tsx
@@ -1,12 +1,13 @@
 import { Button, ColorSwatch, Input, Label, Links, Picker } from "@/components";
 import { cn } from "@/lib";
-import { ChevronDown, X } from "lucide-react";
+import { ChevronDown, Copy, X } from "lucide-react";
 import { useColorsLayersContext } from "./Context";
 import { usePaletteContext } from "@/context";
 import { LayerProps } from "./types";
 
 export function Layer({ vertex }: LayerProps) {
-    const { isExpanded, setExpanded, removeItem } = useColorsLayersContext();
+    const { isExpanded, setExpanded, removeItem, duplicateItem } =
+        useColorsLayersContext();
 
     const { colorSpace, updateColorName, updateColorData } =
         usePaletteContext();
@@ -52,9 +53,14 @@ export function Layer({ vertex }: LayerProps) {
                 <div
                     className={cn(
                         "flex",
-                        "gap-2",
+                        "border",
                         "items-center",
-                        "justify-end"
+                        "border-gray-800",
+                        "justify-end",
+                        "opacity-0",
+                        "group-hover:opacity-100",
+                        "duration-300",
+                        "transition"
                     )}
                 >
                     <Button
@@ -62,18 +68,28 @@ export function Layer({ vertex }: LayerProps) {
                         aria-label={`remove ${title}`}
                         onPress={() => removeItem(vertex.id)}
                         className={cn(
-                            "opacity-0",
-                            "group-hover:opacity-100",
-                            "duration-300",
-                            "transition",
                             "text-gray-400",
-                            "group-hover:border-red-500",
+                            "border-0",
                             "group-hover:text-red-500",
                             "hover:bg-red-200",
                             "hover:text-red-900"
                         )}
                     >
                         <X size={16} />
+                    </Button>
+                    <Button
+                        variant={"trigger"}
+                        aria-label={"duplicate"}
+                        onPress={() => {
+                            duplicateItem(vertex.id);
+                        }}
+                        className={cn(
+                            "border-0",
+                            "border-x",
+                            "hover:bg-gray-200"
+                        )}
+                    >
+                        <Copy size={16} />
                     </Button>
                     <Button
                         variant={"trigger"}
@@ -84,13 +100,7 @@ export function Layer({ vertex }: LayerProps) {
                         onPress={() => {
                             setExpanded(vertex.id);
                         }}
-                        className={cn(
-                            "opacity-0",
-                            "group-hover:opacity-100",
-                            "duration-300",
-                            "transition",
-                            "hover:bg-gray-200"
-                        )}
+                        className={cn("border-0", "hover:bg-gray-200")}
                     >
                         <ChevronDown
                             className={cn(

--- a/src/features/colors-layers/Layer.tsx
+++ b/src/features/colors-layers/Layer.tsx
@@ -1,4 +1,13 @@
-import { Button, ColorSwatch, Input, Label, Links, Picker } from "@/components";
+import {
+    Button,
+    ButtonGroup,
+    ButtonGroupItem,
+    ColorSwatch,
+    Input,
+    Label,
+    Links,
+    Picker,
+} from "@/components";
 import { cn } from "@/lib";
 import { ChevronDown, Copy, X } from "lucide-react";
 import { useColorsLayersContext } from "./Context";
@@ -50,7 +59,7 @@ export function Layer({ vertex }: LayerProps) {
                     <ColorSwatch size="large" color={vertex.color.data} />
                     {title}
                 </div>
-                <div
+                <ButtonGroup
                     className={cn(
                         "flex",
                         "border",
@@ -59,59 +68,77 @@ export function Layer({ vertex }: LayerProps) {
                         "justify-end",
                         "opacity-0",
                         "group-hover:opacity-100",
+                        "focus-within:opacity-100",
                         "duration-300",
                         "transition"
                     )}
                 >
-                    <Button
-                        variant={"trigger"}
-                        aria-label={`remove ${title}`}
-                        onPress={() => removeItem(vertex.id)}
-                        className={cn(
-                            "text-gray-400",
-                            "border-0",
-                            "group-hover:text-red-500",
-                            "hover:bg-red-200",
-                            "hover:text-red-900"
-                        )}
+                    <ButtonGroupItem
+                        trigger={
+                            <Button
+                                variant={"trigger"}
+                                aria-label={`remove ${title}`}
+                                onPress={() => removeItem(vertex.id)}
+                                className={cn(
+                                    "border-0",
+                                    "group-hover:text-red-500",
+                                    "hover:bg-red-200",
+                                    "hover:text-red-900"
+                                )}
+                            >
+                                <X size={16} />
+                            </Button>
+                        }
+                    >{`remove ${title}`}</ButtonGroupItem>
+                    <ButtonGroupItem
+                        trigger={
+                            <Button
+                                variant={"trigger"}
+                                aria-label={`duplicate ${title}`}
+                                onPress={() => {
+                                    duplicateItem(vertex.id);
+                                }}
+                                className={cn(
+                                    "border-0",
+                                    // "border-x",
+                                    "hover:bg-gray-200"
+                                )}
+                            >
+                                <Copy size={16} />
+                            </Button>
+                        }
+                    >{`duplicate ${title}`}</ButtonGroupItem>
+                    <ButtonGroupItem
+                        trigger={
+                            <Button
+                                variant={"trigger"}
+                                aria-expanded={isLayerExpanded}
+                                aria-controls={vertex.id}
+                                aria-label={
+                                    !isLayerExpanded ? "expand" : "collapse"
+                                }
+                                id={`trigger-item-${vertex.id}`}
+                                onPress={() => {
+                                    setExpanded(vertex.id);
+                                }}
+                                className={cn("border-0", "hover:bg-gray-200")}
+                            >
+                                <ChevronDown
+                                    className={cn(
+                                        "transform",
+                                        "duration-300",
+                                        !isLayerExpanded && "-rotate-90"
+                                    )}
+                                    size={16}
+                                />
+                            </Button>
+                        }
                     >
-                        <X size={16} />
-                    </Button>
-                    <Button
-                        variant={"trigger"}
-                        aria-label={"duplicate"}
-                        onPress={() => {
-                            duplicateItem(vertex.id);
-                        }}
-                        className={cn(
-                            "border-0",
-                            "border-x",
-                            "hover:bg-gray-200"
-                        )}
-                    >
-                        <Copy size={16} />
-                    </Button>
-                    <Button
-                        variant={"trigger"}
-                        aria-expanded={isLayerExpanded}
-                        aria-controls={vertex.id}
-                        aria-label={!isLayerExpanded ? "expand" : "collapse"}
-                        id={`trigger-item-${vertex.id}`}
-                        onPress={() => {
-                            setExpanded(vertex.id);
-                        }}
-                        className={cn("border-0", "hover:bg-gray-200")}
-                    >
-                        <ChevronDown
-                            className={cn(
-                                "transform",
-                                "duration-300",
-                                !isLayerExpanded && "-rotate-90"
-                            )}
-                            size={16}
-                        />
-                    </Button>
-                </div>
+                        {!isLayerExpanded
+                            ? `expand ${title}`
+                            : `collapse ${title}`}
+                    </ButtonGroupItem>
+                </ButtonGroup>
             </h3>
             <div
                 id={vertex.id}

--- a/src/features/colors-layers/Layers.tsx
+++ b/src/features/colors-layers/Layers.tsx
@@ -2,9 +2,9 @@ import { useAppContext } from "@/context";
 import { Layer } from "./Layer";
 
 export function Layers() {
-    const { bfsAll } = useAppContext();
+    const { getVertices } = useAppContext();
 
-    return bfsAll((vertex) => {
+    return getVertices().map((vertex) => {
         return <Layer key={vertex.id} vertex={vertex} />;
     });
 }

--- a/src/features/colors-layers/types.ts
+++ b/src/features/colors-layers/types.ts
@@ -1,4 +1,4 @@
-import { AppType, Node } from "@/context";
+import { AppType, Node, PaletteContextCallback } from "@/context";
 
 export type LayerProps = {
     vertex: Node;
@@ -7,5 +7,6 @@ export type LayerProps = {
 export type ColorsLayersContextType = {
     setExpanded: (id: string) => void;
     removeItem: AppType["removeVertex"];
+    duplicateItem: PaletteContextCallback["onColorDuplicate"];
     isExpanded: (id: string) => boolean;
 };

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -2,3 +2,4 @@ export * from "./color-graph";
 export * from "./colors-layers";
 export * from "./toolbar";
 export * from "./zoom";
+export * from "./node-option";

--- a/src/features/node-option/NodeOption.tsx
+++ b/src/features/node-option/NodeOption.tsx
@@ -1,0 +1,135 @@
+import {
+    Button,
+    ButtonGroup,
+    ButtonGroupItem,
+    ColorSwatch,
+} from "@/components";
+import { useNodeOptionsContext } from "@/context";
+import { cn } from "@/lib";
+import { ArrowDownToDot, ArrowUpFromDot, CircleX, Copy, X } from "lucide-react";
+
+export function NodeOption() {
+    const {
+        connection,
+        selected,
+        floatingStyles,
+        node,
+        floatingRef,
+        floatingProps,
+        removeNode,
+        duplicateNode,
+        setConnection,
+        resetConnection,
+    } = useNodeOptionsContext();
+
+    return (
+        selected && (
+            <div
+                ref={floatingRef}
+                style={floatingStyles}
+                {...floatingProps()}
+                className={cn(
+                    "flex",
+                    "flex-col",
+                    "bg-white",
+                    "border-black",
+                    "border",
+                    "shadow-md"
+                )}
+            >
+                <span
+                    className={cn(
+                        "flex",
+                        "items-center",
+                        "gap-2",
+                        "p-1",
+                        "text-sm",
+                        "border-b",
+                        "border-gray-800",
+                        "text-ellipsis",
+                        "overflow-hidden",
+                        "max-w-xs"
+                    )}
+                >
+                    <ColorSwatch color={node?.color.data} />
+                    {node?.color.data.toString("hex")}
+                </span>
+                <ButtonGroup>
+                    <ButtonGroupItem
+                        trigger={
+                            <Button
+                                variant={"trigger"}
+                                onPress={() => removeNode(selected)}
+                                className={cn(
+                                    "border-0",
+                                    "group-hover:text-red-500",
+                                    "hover:bg-red-200",
+                                    "hover:text-red-900"
+                                )}
+                                aria-label="remove color"
+                            >
+                                <X size={16} />
+                            </Button>
+                        }
+                    >
+                        {"remove"}
+                    </ButtonGroupItem>
+                    <ButtonGroupItem
+                        trigger={
+                            <Button
+                                variant={"trigger"}
+                                onPress={() => duplicateNode(selected)}
+                                className={cn("border-0")}
+                                aria-label="duplicate color"
+                            >
+                                <Copy size={16} />
+                            </Button>
+                        }
+                    >
+                        {"duplicate"}
+                    </ButtonGroupItem>
+                    <ButtonGroupItem
+                        trigger={
+                            connection?.source === selected ? (
+                                <Button
+                                    variant={"trigger"}
+                                    onPress={resetConnection}
+                                    className={cn("border-0")}
+                                    aria-label="cancel source"
+                                >
+                                    <CircleX size={16} />
+                                </Button>
+                            ) : typeof connection?.source === "string" ? (
+                                <Button
+                                    variant={"trigger"}
+                                    onPress={() => setConnection(selected)}
+                                    className={cn("border-0")}
+                                    aria-label="set target"
+                                >
+                                    <ArrowDownToDot size={16} />
+                                </Button>
+                            ) : (
+                                <Button
+                                    variant={"trigger"}
+                                    onPress={() => setConnection(selected)}
+                                    className={cn("border-0")}
+                                    aria-label="set source"
+                                >
+                                    <ArrowUpFromDot size={16} />
+                                </Button>
+                            )
+                        }
+                    >
+                        {connection?.source === selected
+                            ? "cancel source"
+                            : connection?.target === selected
+                            ? "cancel target"
+                            : typeof connection?.source === "string"
+                            ? "set target"
+                            : "set source"}
+                    </ButtonGroupItem>
+                </ButtonGroup>
+            </div>
+        )
+    );
+}

--- a/src/features/node-option/index.ts
+++ b/src/features/node-option/index.ts
@@ -1,0 +1,1 @@
+export * from "./NodeOption";

--- a/src/features/toolbar/Toolbar.tsx
+++ b/src/features/toolbar/Toolbar.tsx
@@ -54,6 +54,8 @@ export function Toolbar({ className }: ToolbarProps) {
                 "z-10",
                 "left-1/2",
                 "-ml-12",
+                "mt-2",
+                "lg:mt-3",
 
                 visible
                     ? "opacity-100"


### PR DESCRIPTION
This PR fix some issues and add popover options to node when clicked giving user the option to remove, duplicate and link the node

- **fix(button): fix hover bg**
- **feat(pallete.provider): onColorDuplicate method**
- **feat(colors-layers): add duplicate button for each layer**
- **feat(button-group): add ref type and remove margins**
- **fix(toolbar): set margins to toolbar**
- **fix(links): refactor & fix links to show color hex instead of id when no title is present**
- **fix(picker.provider): simplify methods passing color direct instead of converting it to hex**
- **fix(color-field): add Color value**
- **fix(solor-swatch): remove rounded**
- **feat(color-thumb): add focus-within css**
- **fix(color-picker): simplify layout removing unnecessary div**
- **fix(colors-layers): change layer actions layout to button group with tooltips and etc**
- **feat(app): graph instance and setGraphInstance method**
- **fix(palette): simplify onLinkRemove callback**
- **feat(node-options.provider): introduces node options provider**
- **feat(node-option): introduces node-options component**
- **feat(color-graph): integrate color-graph to node-options**
- **feat(app): add node options provider to dom tree and add floating ui as deps**


closes #75, closes #69

